### PR TITLE
SDF: support plugin with repeated elements

### DIFF
--- a/pcg_gazebo/parsers/sdf/plugin.py
+++ b/pcg_gazebo/parsers/sdf/plugin.py
@@ -57,7 +57,17 @@ class Plugin(XMLCustom):
         assert is_string(tag), 'Input tag' \
             ' must be string or unicode, received={}, type={}'.format(
                 tag, type(tag))
-        self._value[tag] = value
+
+        # has multiple elements with the same tag
+        if tag in self._value:
+            if isinstance(self._value[tag], list):
+                self._value[tag].append(value)
+            else:
+                tmp = self._value[tag]
+                self._value[tag] = list([tmp, value])
+
+        else:
+            self._value[tag] = value
 
     def from_dict(self, sdf_data, ignore_tags=list()):
         XMLCustom.from_dict(self, sdf_data)

--- a/pcg_gazebo/parsers/types/custom.py
+++ b/pcg_gazebo/parsers/types/custom.py
@@ -42,6 +42,36 @@ class XMLCustom(XMLBase):
                     child = Element(tag, attrib=value[tag]['attributes'])
                     self._get_elem_as_xml(child, value[tag]['value'])
                     xml_elem.append(child)
+
+                elif isinstance(value[tag], list):
+                    # check if the list contains repeated elements
+                    n_elem = 0
+                    for item in value[tag]:
+                        if isinstance(item, dict) and \
+                            'attributes' in item and \
+                            'value' in item:
+                            n_elem += 1
+
+                    # either all items are elements or none are 
+                    has_mult = n_elem == len(value[tag])
+                    is_valid = not (n_elem > 0 and not has_mult)
+
+                    assert is_valid, \
+                        "XML data has invalid repeated element for tag {}".format(tag)  
+
+                    if has_mult:
+                        # repeated elements
+                        for item in value[tag]:
+                            child = Element(tag, attrib=item['attributes'])
+                            self._get_elem_as_xml(child, item['value'])
+                            xml_elem.append(child)
+                    else:
+                        # single element containing a list
+                        child = Element(tag)
+                        output_str = ' '.join(['{}'] * len(value[tag]))
+                        child.text = output_str.format(*value[tag])
+                        xml_elem.append(child)
+
                 elif tag.startswith('@'):
                     xml_elem.set(tag.replace('@', ''), value[tag])
                 else:


### PR DESCRIPTION
This PR adds support for SDF plugins that contain repeated elements (#139)

Repeated elements are specified by assigning a list to a tag in a dictionary of plugin arguments. For example running the code:

```python
from pcg_gazebo.parsers.sdf import create_sdf_element
from pcg_gazebo.parsers.sdf import Plugin

plugin_args = dict(
    control=list([  
        dict(
            attributes=dict(
                channel="0"
            ),
            value=dict(
                jointName='steer_joint',
                useForce=1
            )
        ),
        dict(
            attributes=dict(
                channel="2"
            ),
            value=dict(
                jointName='motor_joint',
                useForce=1
            )
        )        
    ])
)

plugin = create_sdf_element('plugin')
plugin.name = 'plugin'
plugin.filename = 'libPlugin.so'
plugin.value = plugin_args
print(plugin)
``` 

ouputs

```xml
<plugin name="plugin" filename="libPlugin.so">
  <control channel="0">
    <jointName>steer_joint</jointName>
    <useForce>1</useForce>
  </control>
  <control channel="2">
    <jointName>motor_joint</jointName>
    <useForce>1</useForce>
  </control>
</plugin>
```

Lists of numbers and strings continue to work as before:

```python
plugin_args = dict(
    xyz=[1.0, 2.0, 3.0],
    rpy=[0.1, 0.2, 0.3],
)

plugin = create_sdf_element('plugin')
plugin.name = 'plugin'
plugin.filename = 'libPlugin.so'
plugin.from_dict(plugin_args)
print(plugin)
```

```xml
<plugin name="plugin" filename="libPlugin.so">
  <xyz>1.0 2.0 3.0</xyz>
  <rpy>0.1 0.2 0.3</rpy>
</plugin>
```

