### PR TITLE
replaced collection.Iterable by collection.abc.Iterable

### DIFF
--- a/pcg_gazebo/generators/constraints/workspace_constraint.py
+++ b/pcg_gazebo/generators/constraints/workspace_constraint.py
@@ -390,7 +390,7 @@ class WorkspaceConstraint(Constraint):
 
         * `point` (*type:* `list` or `numpy.ndarray`): 2D point
         """
-        assert isinstance(point, collections.Iterable), \
+        assert isinstance(point, collections.abc.Iterable), \
             'Invalid list of points'
         point = list(point)
         geo = self.get_geometry()
@@ -399,7 +399,7 @@ class WorkspaceConstraint(Constraint):
         return geo.contains(pnt)
 
     def contains_points(self, points):
-        assert isinstance(points, collections.Iterable), \
+        assert isinstance(points, collections.abc.Iterable), \
             'Invalid list of points'
         points = MultiPoint(points)
         geo = self.get_geometry()
@@ -412,7 +412,7 @@ class WorkspaceConstraint(Constraint):
 
         * `polygons` (*type:* list of `shapely.Polygon`): List of polygons
         """
-        assert isinstance(polygons, collections.Iterable), \
+        assert isinstance(polygons, collections.abc.Iterable), \
             'Invalid list of polygons'
         merged_poly = None
         geo = self.get_geometry()

--- a/pcg_gazebo/generators/creators.py
+++ b/pcg_gazebo/generators/creators.py
@@ -49,7 +49,7 @@ def _parse_factory_input_as_vector(var):
             var))
         return np.array([var])
 
-    if isinstance(var, collections.Iterable) and not is_string(var):
+    if isinstance(var, collections.abc.Iterable) and not is_string(var):
         PCG_ROOT_LOGGER.info('Variable provided as vector={}'.format(
             var))
         return np.array(var)
@@ -70,7 +70,7 @@ def _parse_factory_input_as_vector(var):
             PCG_ROOT_LOGGER.info('Variable provided as scalar={}'.format(
                 var))
             return np.array([vars])
-        elif not isinstance(vars, collections.Iterable):
+        elif not isinstance(vars, collections.abc.Iterable):
             if callable(vars):
                 vars = vars()
             else:

--- a/pcg_gazebo/generators/engines/engine.py
+++ b/pcg_gazebo/generators/engines/engine.py
@@ -235,7 +235,7 @@ class Engine(object):
         """
         assert model in self._models, \
             'Model {} is not an asset for this engine'.format(model)
-        assert isinstance(pose, collections.Iterable), \
+        assert isinstance(pose, collections.abc.Iterable), \
             'Pose must be an array or a vector'
         pose = list(pose)
         assert len(pose) == 6 or len(pose) == 7, \

--- a/pcg_gazebo/generators/mesh.py
+++ b/pcg_gazebo/generators/mesh.py
@@ -74,7 +74,7 @@ def sweep():
 
 def box(size):
     import collections
-    assert isinstance(size, collections.Iterable), 'Size is not an array'
+    assert isinstance(size, collections.abc.Iterable), 'Size is not an array'
     vec = list(size)
     assert len(vec) == 3, 'Input size array must have 3 elements'
     for elem in vec:

--- a/pcg_gazebo/parsers/__init__.py
+++ b/pcg_gazebo/parsers/__init__.py
@@ -671,7 +671,7 @@ def urdf2sdf(urdf):
                     for tag in gazebo.children:
                         if isinstance(
                                 gazebo.children[tag],
-                                collections.Iterable):
+                                collections.abc.Iterable):
                             for elem in gazebo.children[tag]:
                                 if elem._TYPE != 'sdf':
                                     continue
@@ -686,7 +686,8 @@ def urdf2sdf(urdf):
     if hasattr(urdf, 'gazebo'):
         if urdf.gazebo is not None:
             for tag in urdf.gazebo.children:
-                if isinstance(urdf.gazebo.children[tag], collections.Iterable):
+                if isinstance(
+                        urdf.gazebo.children[tag], collections.abc.Iterable):
                     for elem in urdf.gazebo.children[tag]:
                         if elem._TYPE != 'sdf':
                             continue

--- a/pcg_gazebo/parsers/sdf/direction.py
+++ b/pcg_gazebo/parsers/sdf/direction.py
@@ -26,7 +26,7 @@ class Direction(XMLBase):
             self._is_scalar(default), \
             'Direction must be either an array or a scalar'
 
-        if isinstance(default, collections.Iterable):
+        if isinstance(default, collections.abc.Iterable):
             default = list(default)
             assert len(default) == 3, \
                 'Direction must have 3 components'
@@ -38,7 +38,7 @@ class Direction(XMLBase):
         self._value = default
 
     def _set_value(self, value):
-        if isinstance(value, collections.Iterable):
+        if isinstance(value, collections.abc.Iterable):
             assert len(value) == 3, \
                 'Direction must have 3 components'
             assert self._is_numeric_vector(value), \
@@ -48,7 +48,7 @@ class Direction(XMLBase):
             self._value = float(value)
 
     def get_formatted_value_as_str(self):
-        if isinstance(self._value, collections.Iterable):
+        if isinstance(self._value, collections.abc.Iterable):
             output_str = ' '.join(['{}'] * len(self._value))
             return output_str.format(*[format(x, 'n') for x in self._value])
         else:

--- a/pcg_gazebo/parsers/sdf/fdir1.py
+++ b/pcg_gazebo/parsers/sdf/fdir1.py
@@ -36,7 +36,7 @@ class FDir1(XMLVector):
 
     def _set_value(self, value):
         assert isinstance(
-            value, collections.Iterable), 'Input must be iterable'
+            value, collections.abc.Iterable), 'Input must be iterable'
         assert len(list(value)) == self._size, 'Wrong size'
         for item in value:
             assert isinstance(item, float) or isinstance(item, int), \

--- a/pcg_gazebo/parsers/sdf/gravity.py
+++ b/pcg_gazebo/parsers/sdf/gravity.py
@@ -24,7 +24,7 @@ class Gravity(XMLBase):
         super(Gravity, self).__init__()
         assert self._is_boolean(default) or self._is_numeric_vector(default)
 
-        if isinstance(default, collections.Iterable):
+        if isinstance(default, collections.abc.Iterable):
             default = list(default)
             assert len(default) == 3
             assert self._is_numeric_vector(default)
@@ -39,7 +39,7 @@ class Gravity(XMLBase):
                 'Boolean value must be a boolean, 0 or 1'
             self._value = bool(value)
         else:
-            if isinstance(value, collections.Iterable):
+            if isinstance(value, collections.abc.Iterable):
                 assert len(list(value)) == 3
                 for elem in value:
                     assert isinstance(elem, float) or isinstance(elem, int)

--- a/pcg_gazebo/parsers/types/base.py
+++ b/pcg_gazebo/parsers/types/base.py
@@ -411,11 +411,11 @@ class XMLBase(object):
                                 else:
                                     obj._add_child_element(elem, value[elem])
                     _add_element(obj)
-                elif isinstance(value, collections.Iterable) and \
+                elif isinstance(value, collections.abc.Iterable) and \
                         not is_string(value) and \
                         not _create_element(tag).has_value():
                     for subelem in value:
-                        if isinstance(subelem, collections.Iterable) and \
+                        if isinstance(subelem, collections.abc.Iterable) and \
                                 not is_string(subelem):
                             obj = _create_element(tag)
                             for elem in subelem:

--- a/pcg_gazebo/parsers/types/vector.py
+++ b/pcg_gazebo/parsers/types/vector.py
@@ -36,7 +36,7 @@ class XMLVector(XMLBase):
     def _set_value(self, value):
         if self._size == 1 and self._is_scalar(value):
             value = [value]
-        assert isinstance(value, collections.Iterable), \
+        assert isinstance(value, collections.abc.Iterable), \
             'Input must be iterable, element={}, received={}, type={}'.format(
                 self._NAME, value, type(value))
         assert len(list(value)) == self._size, \

--- a/pcg_gazebo/parsers/urdf/color.py
+++ b/pcg_gazebo/parsers/urdf/color.py
@@ -39,7 +39,7 @@ class Color(XMLBase):
 
     @rgba.setter
     def rgba(self, value):
-        assert isinstance(value, collections.Iterable), \
+        assert isinstance(value, collections.abc.Iterable), \
             'Input must be iterable'
         assert len(value) == 4, 'Color vector must have 4 components'
         for elem in value:

--- a/pcg_gazebo/simulation/box.py
+++ b/pcg_gazebo/simulation/box.py
@@ -36,7 +36,7 @@ class Box(Link):
         self._collisions = [Collision()]
         self._visuals = [Visual()]
 
-        assert isinstance(size, collections.Iterable), \
+        assert isinstance(size, collections.abc.Iterable), \
             'Input size vector must be a list'
         assert len(size) == 3, 'Size vector must be have 3 elements'
 

--- a/pcg_gazebo/simulation/joint.py
+++ b/pcg_gazebo/simulation/joint.py
@@ -128,7 +128,7 @@ class Joint(object):
         if isinstance(vec, Pose):
             self._pose = vec
         else:
-            assert isinstance(vec, collections.Iterable), \
+            assert isinstance(vec, collections.abc.Iterable), \
                 'Input vector must be iterable'
             assert len(vec) == 6 or len(vec) == 7, \
                 'Input vector must have either 6 or 7 elements'

--- a/pcg_gazebo/simulation/light.py
+++ b/pcg_gazebo/simulation/light.py
@@ -78,7 +78,7 @@ class Light(object):
         if isinstance(vec, Pose):
             self._pose = vec
         else:
-            assert isinstance(vec, collections.Iterable), \
+            assert isinstance(vec, collections.abc.Iterable), \
                 'Input pose vector must be iterable, received={}'.format(vec)
             assert len(vec) == 6 or len(vec) == 7, \
                 'Pose must be given as position and Euler angles (x, y, z, ' \

--- a/pcg_gazebo/simulation/link.py
+++ b/pcg_gazebo/simulation/link.py
@@ -247,7 +247,7 @@ class Link(Entity):
                 link.get_visual_by_name('visual').set_xkcd_color()
             elif is_string(color):
                 link.get_visual_by_name('visual').set_xkcd_color(color)
-            elif isinstance(color, collections.Iterable) and \
+            elif isinstance(color, collections.abc.Iterable) and \
                     len(list(color)) == 3:
                 link.get_visual_by_name('visual').set_color(*color)
 

--- a/pcg_gazebo/simulation/model.py
+++ b/pcg_gazebo/simulation/model.py
@@ -287,7 +287,8 @@ class SimulationModel(Entity):
             visual_parameters=dict(),
             collision_parameters=dict()):
         assert is_string(link_name), 'Link name must be a string'
-        assert isinstance(size, collections.Iterable), 'Size must be an array'
+        assert isinstance(
+            size, collections.abc.Iterable), 'Size must be an array'
         assert len(list(size)) == 3, 'Input size must have 3 elements'
         assert isinstance(
             visual_parameters, dict), 'Visual geometry' \
@@ -380,7 +381,7 @@ class SimulationModel(Entity):
                             link.get_visual_by_name(
                                 'visual').material.diffuse.value,
                             link_name))
-                elif isinstance(color, collections.Iterable) and \
+                elif isinstance(color, collections.abc.Iterable) and \
                         len(list(color)) == 4:
                     link.get_visual_by_name('visual').set_color(*color)
                     PCG_ROOT_LOGGER.info(
@@ -507,7 +508,7 @@ class SimulationModel(Entity):
                     link.get_visual_by_name('visual').set_xkcd_color()
                 elif is_string(color):
                     link.get_visual_by_name('visual').set_xkcd_color(color)
-                elif isinstance(color, collections.Iterable) and \
+                elif isinstance(color, collections.abc.Iterable) and \
                         len(list(color)) == 4:
                     link.get_visual_by_name('visual').set_color(*color)
         else:
@@ -630,7 +631,7 @@ class SimulationModel(Entity):
                     link.get_visual_by_name('visual').set_xkcd_color()
                 elif is_string(color):
                     link.get_visual_by_name('visual').set_xkcd_color(color)
-                elif isinstance(color, collections.Iterable) and \
+                elif isinstance(color, collections.abc.Iterable) and \
                         len(list(color)) == 4:
                     link.get_visual_by_name('visual').set_color(*color)
         else:
@@ -1521,7 +1522,7 @@ class SimulationModel(Entity):
             pose_offset = Pose()
 
         if z_limits is not None:
-            if not isinstance(z_limits, collections.Iterable):
+            if not isinstance(z_limits, collections.abc.Iterable):
                 msg = 'Z limits input has to be a list, provided={}'.format(
                     z_limits)
                 PCG_ROOT_LOGGER.error(msg)

--- a/pcg_gazebo/simulation/model_group.py
+++ b/pcg_gazebo/simulation/model_group.py
@@ -363,7 +363,7 @@ class ModelGroup(Entity):
             pose_offset = Pose()
 
         if z_limits is not None:
-            if not isinstance(z_limits, collections.Iterable):
+            if not isinstance(z_limits, collections.abc.Iterable):
                 msg = 'Z limits input has to be a list, provided={}'.format(
                     z_limits)
                 PCG_ROOT_LOGGER.error(msg)

--- a/pcg_gazebo/simulation/properties/axis.py
+++ b/pcg_gazebo/simulation/properties/axis.py
@@ -91,7 +91,7 @@ class Axis(object):
         return self._use_parent_model_frame
 
     def set_axis(self, vec):
-        assert isinstance(vec, collections.Iterable), \
+        assert isinstance(vec, collections.abc.Iterable), \
             'Input vector must be a list or an array'
         vec = list(vec)
         assert len(vec) == 3, 'Input axis vector must have three elements'

--- a/pcg_gazebo/simulation/properties/bounding_box.py
+++ b/pcg_gazebo/simulation/properties/bounding_box.py
@@ -33,9 +33,9 @@ class BoundingBox(object):
         return self._max
 
     def set_bbox(self, min_corner=[0, 0, 0], max_corner=[0, 0, 0]):
-        assert isinstance(min_corner, collections.Iterable), \
+        assert isinstance(min_corner, collections.abc.Iterable), \
             'Min. corner point must be iterable'
-        assert isinstance(max_corner, collections.Iterable), \
+        assert isinstance(max_corner, collections.abc.Iterable), \
             'Max. corner point must be iterable'
         min_corner = list(min_corner)
         max_corner = list(max_corner)

--- a/pcg_gazebo/simulation/properties/collision.py
+++ b/pcg_gazebo/simulation/properties/collision.py
@@ -162,7 +162,7 @@ class Collision(object):
         if isinstance(vec, Pose):
             self._pose = vec
         else:
-            assert isinstance(vec, collections.Iterable), \
+            assert isinstance(vec, collections.abc.Iterable), \
                 'Input vector must be iterable'
             assert len(vec) == 6 or len(vec) == 7, \
                 'Input vector must have either 6 or 7 elements'

--- a/pcg_gazebo/simulation/properties/footprint.py
+++ b/pcg_gazebo/simulation/properties/footprint.py
@@ -30,7 +30,7 @@ class Footprint(object):
         self._polygons.append(polygon)
 
     def add_circle(self, center, radius):
-        assert isinstance(center, collections.Iterable), \
+        assert isinstance(center, collections.abc.Iterable), \
             'Center must be a list or an array'
         center = list(center)
         assert len(center) == 2, \
@@ -67,7 +67,7 @@ class Footprint(object):
         return footprint
 
     def set_offset(self, offset):
-        assert isinstance(offset, collections.Iterable), \
+        assert isinstance(offset, collections.abc.Iterable), \
             'Offset must be a list or an array'
         offset = list(offset)
         assert len(offset) == 2, \

--- a/pcg_gazebo/simulation/properties/geometry.py
+++ b/pcg_gazebo/simulation/properties/geometry.py
@@ -289,7 +289,7 @@ class Geometry(object):
             return None
 
     def set_box(self, size):
-        assert isinstance(size, collections.Iterable), \
+        assert isinstance(size, collections.abc.Iterable), \
             'Invalid input array'
         size = list(size)
         assert len(size) == 3, 'Input size vector must have 3 elements'
@@ -321,14 +321,14 @@ class Geometry(object):
         self._geo_type = 'sphere'
 
     def set_plane(self, size, normal):
-        assert isinstance(size, collections.Iterable), \
+        assert isinstance(size, collections.abc.Iterable), \
             'Invalid size array'
         size = list(size)
         assert len(size) == 2, 'Input size vector must have 2 elements'
         for elem in size:
             assert elem > 0, 'Size element must be greater than zero'
 
-        assert isinstance(normal, collections.Iterable), \
+        assert isinstance(normal, collections.abc.Iterable), \
             'Invalid normal array'
         normal = list(normal)
         assert len(normal) == 3, 'Input normal vector must have 3 elements'

--- a/pcg_gazebo/simulation/properties/inertial.py
+++ b/pcg_gazebo/simulation/properties/inertial.py
@@ -62,7 +62,7 @@ class Inertial(object):
         if isinstance(vec, Pose):
             self._pose = vec
         else:
-            assert isinstance(vec, collections.Iterable), \
+            assert isinstance(vec, collections.abc.Iterable), \
                 'Input pose vector must be iterable'
             assert len(vec) == 6 or len(vec) == 7, \
                 'Pose must be given as position and Euler angles (x, y, z, ' \

--- a/pcg_gazebo/simulation/properties/mesh.py
+++ b/pcg_gazebo/simulation/properties/mesh.py
@@ -109,7 +109,8 @@ class Mesh(object):
 
     @staticmethod
     def create_box(size=[1, 1, 1]):
-        assert isinstance(size, collections.Iterable), 'Size is not an array'
+        assert isinstance(
+            size, collections.abc.Iterable), 'Size is not an array'
         vec = list(size)
         assert len(vec) == 3, 'Input size array must have 3 elements'
         for elem in vec:
@@ -183,7 +184,8 @@ class Mesh(object):
 
     @scale.setter
     def scale(self, vec):
-        assert isinstance(vec, collections.Iterable), 'Input is not an array'
+        assert isinstance(
+            vec, collections.abc.Iterable), 'Input is not an array'
         vec = list(vec)
         assert len(vec) == 3, \
             'Input scale array must have 3 elements,' \
@@ -361,7 +363,7 @@ class Mesh(object):
     def get_meshes(self, scale=None):
         if scale is not None:
             assert isinstance(
-                scale, collections.Iterable), 'Input is not an array'
+                scale, collections.abc.Iterable), 'Input is not an array'
             scale = list(scale)
             assert len(scale) == 3, \
                 'Input scale array must have 3 elements,' \

--- a/pcg_gazebo/simulation/properties/pose.py
+++ b/pcg_gazebo/simulation/properties/pose.py
@@ -28,7 +28,7 @@ from ...utils import is_scalar
 class Pose(object):
     def __init__(self, pos=None, rot=None):
         if pos is not None:
-            assert isinstance(pos, collections.Iterable), \
+            assert isinstance(pos, collections.abc.Iterable), \
                 'Input vector must be iterable'
             assert len(list(pos)) == 3, \
                 'Position vector must have 3 elements'
@@ -38,7 +38,7 @@ class Pose(object):
         self._quat = np.array([0, 0, 0, 1])
 
         if rot is not None:
-            assert isinstance(rot, collections.Iterable), \
+            assert isinstance(rot, collections.abc.Iterable), \
                 'Input rot vector must be iterable'
             if len(list(rot)) == 3:
                 rpy = list(rot)
@@ -112,7 +112,7 @@ class Pose(object):
 
     @position.setter
     def position(self, value):
-        assert isinstance(value, collections.Iterable), \
+        assert isinstance(value, collections.abc.Iterable), \
             'Input vector must be iterable'
         assert len(list(value)) == 3, \
             'Position vector must have 3 elements'
@@ -154,7 +154,7 @@ class Pose(object):
 
     @rpy.setter
     def rpy(self, value):
-        assert isinstance(value, collections.Iterable), \
+        assert isinstance(value, collections.abc.Iterable), \
             'Input vector must be iterable'
         assert len(list(value)) == 3, \
             'Input vector must have 3 elements'
@@ -178,7 +178,7 @@ class Pose(object):
 
     @quat.setter
     def quat(self, q):
-        assert isinstance(q, collections.Iterable), \
+        assert isinstance(q, collections.abc.Iterable), \
             'Input vector must be iterable'
         assert len(list(q)) == 4, \
             'Input vector must have 4 elements'

--- a/pcg_gazebo/simulation/properties/visual.py
+++ b/pcg_gazebo/simulation/properties/visual.py
@@ -93,7 +93,7 @@ class Visual(object):
         if isinstance(vec, Pose):
             self._pose = vec
         else:
-            assert isinstance(vec, collections.Iterable), \
+            assert isinstance(vec, collections.abc.Iterable), \
                 'Input vector must be iterable'
             assert len(vec) == 6 or len(vec) == 7, \
                 'Input vector must have either 6 or 7 elements'

--- a/pcg_gazebo/simulation/sensors/sensor.py
+++ b/pcg_gazebo/simulation/sensors/sensor.py
@@ -67,7 +67,7 @@ class Sensor(object):
         if isinstance(vec, Pose):
             self._pose = vec
         else:
-            assert isinstance(vec, collections.Iterable), \
+            assert isinstance(vec, collections.abc.Iterable), \
                 'Input vector must be iterable'
             assert len(vec) == 6 or len(vec) == 7, \
                 'Input vector must have either 6 or 7 elements'

--- a/pcg_gazebo/task_manager/gazebo_proxy.py
+++ b/pcg_gazebo/task_manager/gazebo_proxy.py
@@ -267,14 +267,14 @@ class GazeboProxy(object):
         assert model_name in self.get_model_names(), \
             'Model {} does not exist'.format(model_name)
 
-        assert isinstance(pos, collections.Iterable)
+        assert isinstance(pos, collections.abc.Iterable)
         assert len(list(pos)) == 3, 'Position vector must have three ' \
             'components, (x, y, z)'
         for elem in pos:
             assert isinstance(elem, float) or isinstance(elem, int), \
                 '{} is not a valid number'.format(elem)
 
-        assert isinstance(rot, collections.Iterable), \
+        assert isinstance(rot, collections.abc.Iterable), \
             'Rotation vector must be iterable'
         assert len(list(rot)) == 3 or len(list(rot)) == 4
         for elem in rot:

--- a/pcg_gazebo/utils.py
+++ b/pcg_gazebo/utils.py
@@ -437,7 +437,7 @@ def is_array(obj):
     """
     import collections
     return isinstance(
-        obj, collections.Iterable) and not isinstance(
+        obj, collections.abc.Iterable) and not isinstance(
         obj, str)
 
 


### PR DESCRIPTION
The `collections.Iterable `has been deprecated since Python 3.3 and stopped working in Python 3.10, hence the PR replaces `collection.Iterable` with `collection.abc.Iterable`